### PR TITLE
Safe fix for xcode 16 beta 6

### DIFF
--- a/Sources/CWuffs/include/wuffs-v0.3.h
+++ b/Sources/CWuffs/include/wuffs-v0.3.h
@@ -68,6 +68,8 @@
 extern "C" {
 #endif
 
+#include <stdio.h>
+
 // ---------------- Version
 
 // WUFFS_VERSION is the major.minor.patch version, as per https://semver.org/,


### PR DESCRIPTION
This package doesn’t build on Xcode 16 beta 6, the issue is the missing definition of FILE used by the swift extensions. The fix is simply to include <stdio.h>. This is also a workaround; it would be best to ask Wuffs to add it. However, I’ve read that version 4 still has issues, and as you can imagine, I focused more on getting immediate results than anything else